### PR TITLE
FIX watermark on insider versions without debug symbol requirement. Add RVA resolution, binary scans, and task install. 

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -5,6 +5,14 @@ USAGE:
 
 SUBCOMMANDS:
     <no subcommand> Alias for inject subcommand
-    inject          Injects into the running explorer.exe process's memory to remove the watermark. Does not persist if explorer.exe or system is restarted.
+    inject          Removes the watermark by patching explorer.exe in memory.
+                    Does not persist if explorer.exe or the system is restarted.
+                    Use install-task to automate re-patching.
+    patch-rva <hex> Manually supply the RVA of CDesktopWatermark::s_DesktopBuildPaint,
+                    cache it, and apply the patch. Use this when all automatic
+                    methods fail (e.g. PDB not yet on symbol server).
+    install-task    Installs a scheduled task that re-runs inject at every logon,
+                    so the watermark stays gone across explorer.exe restarts.
+    remove-task     Removes the scheduled task installed by install-task.
     help            Shows this menu
-    about           Shows some information about UWD2
+    about           Shows information about UWD2

--- a/src/cache_pdb.rs
+++ b/src/cache_pdb.rs
@@ -1,37 +1,179 @@
 use std::fs;
+use std::path::Path;
 
 use crate::constants::*;
+use crate::explorer_modinfo::verify_rva;
 use crate::fetch_pdb;
-use crate::fetch_pdb::fetch;
 use crate::parse_pdb::parse_pdb;
+use crate::scan_dll;
+use crate::structural_scan;
 
+/// Resolve the RVA of `CDesktopWatermark::s_DesktopBuildPaint` for the
+/// shell32.dll currently loaded in explorer.exe.
+///
+/// Fallback chain:
+///   1. Local .rva cache hit
+///   2. Microsoft symbol server (PDB download)
+///   3. Multi-pattern binary scan (patterns.bin from a previous PDB run)
+///   4. Structural GDI-call scan (no cached state required)
+///   5. Panic with manual-recovery instructions
 pub fn get_rva(guid: String) -> u32 {
-    // quick way to get usable directory
     let dir = data_dir();
-    // dbg!(dir);
-    // .rva is arbitrary, im storing a single u32 so there isnt exactly a good extension for this
-    let pdbpath = dir.join(guid.clone() + ".rva");
-    if pdbpath.exists() {
-        println!("PDB cached. Reading...");
-        let file = fs::read(pdbpath).unwrap();
-        u32::from_be_bytes(file.try_into().unwrap())
-    } else {
-        println!("PDB not found. Fetching...");
-        let url = fetch_pdb::build_url(guid);
-        let pdbfile = fetch(url);
+    let rva_path = dir.join(guid.clone() + ".rva");
+
+    // 1. Cache hit
+    if rva_path.exists() {
+        println!("RVA cached. Reading...");
+        let file = fs::read(rva_path).unwrap();
+        return u32::from_be_bytes(file.try_into().unwrap());
+    }
+
+    // 2. Symbol server
+    println!("PDB not cached. Fetching from symbol server...");
+    let url = fetch_pdb::build_url(guid.clone());
+    if let Some(pdbfile) = fetch_pdb::try_fetch(url) {
         println!("Fetched! Parsing...");
         let rva = parse_pdb(pdbfile);
         println!("Parsed! Caching...");
-        // remove existing stuff, we dont need to keep around old pdbs that arent valid
-        if dir.exists() {
-            fs::remove_dir_all(&dir).unwrap();
-        }
-        // create directories
-        fs::create_dir_all(&dir).unwrap();
-        // write file
-        // yes im implicitly using BE here for consistency rather than NE
-        fs::write(pdbpath, rva.to_be_bytes()).unwrap();
+        save_rva_and_patterns(&dir, &guid, rva);
         println!("Cached!");
-        rva
+        return rva;
+    }
+
+    // 3. Multi-pattern binary scan
+    println!("PDB unavailable. Trying multi-pattern binary scan...");
+    let dll_bytes = scan_dll::read_dll();
+    if let Some(rva) = try_multi_pattern_scan(&dir, &guid, &dll_bytes) {
+        return rva;
+    }
+
+    // 4. Structural GDI-call scan
+    println!("Trying structural GDI-call scan...");
+    if let Some(rva) = structural_scan::find_by_gdi_calls(&dll_bytes) {
+        let anchor = scan_dll::read_at_rva(&dll_bytes, rva, 8).unwrap_or_default();
+        let verified = unsafe { verify_rva(rva, &anchor) };
+        if verified {
+            println!("Structural scan: verified RVA {rva:#x}. Caching...");
+            save_rva_and_patterns(&dir, &guid, rva);
+            return rva;
+        }
+        eprintln!("Structural scan returned {rva:#x} but live-process verification failed.");
+    }
+
+    // 5. Give up
+    panic!(
+        "\nAll automatic methods failed to locate CDesktopWatermark::s_DesktopBuildPaint.\n\
+         \n\
+         Manual recovery:\n\
+         1. Open x64dbg and attach to explorer.exe\n\
+         2. Search All Modules → String references for \"DesktopBuildPaint\"\n\
+            or: set a breakpoint on SetTextColor and look at the call stack when\n\
+            the desktop refreshes\n\
+         3. Note the RVA  =  function_address - shell32_base\n\
+         4. Run:  uwd2.exe patch-rva <hex-rva>\n"
+    );
+}
+
+/// Try the multi-pattern binary scan using a saved patterns.bin.
+fn try_multi_pattern_scan(dir: &Path, guid: &str, dll_bytes: &[u8]) -> Option<u32> {
+    let patterns_path = dir.join("patterns.bin");
+    if !patterns_path.exists() {
+        eprintln!(
+            "No cached patterns for binary scan.\n\
+             Run UWD2 on a build where the PDB is available, or use patch-rva."
+        );
+        return None;
+    }
+
+    let data = match fs::read(&patterns_path) {
+        Ok(d) => d,
+        Err(e) => { eprintln!("Could not read patterns.bin: {e}"); return None; }
+    };
+    let patterns = match scan_dll::load_patterns(&data) {
+        Some(p) => p,
+        None => { eprintln!("patterns.bin is corrupt or unrecognized version."); return None; }
+    };
+
+    println!("Scanning shell32.dll with {} sub-patterns...", patterns.len());
+    let hits = scan_dll::scan_for_multi_pattern(dll_bytes, &patterns);
+
+    match hits.len() {
+        0 => {
+            eprintln!("Multi-pattern scan: no match — function prologue changed too much.");
+            None
+        }
+        1 => {
+            let file_offset = hits[0];
+            let rva = scan_dll::file_offset_to_rva(dll_bytes, file_offset)?;
+            println!("Found candidate at RVA {rva:#x}. Verifying against live process...");
+
+            let anchor = &patterns[0].1;
+            let verified = unsafe { verify_rva(rva, anchor) };
+            if !verified {
+                eprintln!("Live-process verification failed — bytes at {rva:#x} do not match.");
+                return None;
+            }
+
+            println!("Verified! Caching RVA...");
+            cleanup_old_rva_files(dir);
+            fs::create_dir_all(dir).unwrap();
+            fs::write(dir.join(guid.to_string() + ".rva"), rva.to_be_bytes()).unwrap();
+            println!("Cached!");
+            Some(rva)
+        }
+        n => {
+            eprintln!("Multi-pattern scan: {n} matches — ambiguous, cannot safely patch.");
+            None
+        }
+    }
+}
+
+/// Persist RVA and refresh patterns.bin for the current build.
+///
+/// Called whenever a new RVA is resolved by any method (PDB, patch-rva,
+/// structural scan).  Overwrites patterns.bin so future binary scans use
+/// the most up-to-date function bytes.
+fn save_rva_and_patterns(dir: &Path, guid: &str, rva: u32) {
+    cleanup_old_rva_files(dir);
+    fs::create_dir_all(dir).unwrap();
+    fs::write(dir.join(guid.to_string() + ".rva"), rva.to_be_bytes()).unwrap();
+
+    let dll_bytes = scan_dll::read_dll();
+    match scan_dll::save_patterns(&dll_bytes, rva) {
+        Some(data) => {
+            fs::write(dir.join("patterns.bin"), &data).unwrap();
+            println!(
+                "Cached {} sub-patterns from RVA {rva:#x} for future builds.",
+                data.get(1).copied().unwrap_or(0)
+            );
+        }
+        None => {
+            eprintln!(
+                "Warning: could not read function bytes — \
+                 binary scan unavailable for future builds."
+            );
+        }
+    }
+}
+
+/// Called by `patch-rva`: user supplies an RVA manually, we cache it and
+/// update patterns.bin so the next normal run hits the cache.
+pub fn seed_rva(rva: u32) {
+    let guid = unsafe { crate::explorer_modinfo::get_guid() };
+    let dir = data_dir();
+    save_rva_and_patterns(&dir, &guid, rva);
+}
+
+fn cleanup_old_rva_files(dir: &Path) {
+    if !dir.exists() {
+        return;
+    }
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().map_or(false, |e| e == "rva") {
+                let _ = fs::remove_file(path);
+            }
+        }
     }
 }

--- a/src/explorer_modinfo.rs
+++ b/src/explorer_modinfo.rs
@@ -1,3 +1,4 @@
+use std::ffi::c_void;
 use std::mem::size_of;
 use std::path::Path;
 
@@ -5,8 +6,8 @@ use windows::core::imp::CloseHandle;
 use windows::core::PCSTR;
 use windows::Win32::Foundation::{GetLastError, FALSE, HANDLE, HMODULE};
 use windows::Win32::System::Diagnostics::Debug::{
-    SymGetModuleInfo64, SymInitialize, SymLoadModuleEx, SymSetOptions, IMAGEHLP_MODULE64,
-    SYMOPT_UNDNAME, SYM_LOAD_FLAGS,
+    ReadProcessMemory, SymGetModuleInfo64, SymInitialize, SymLoadModuleEx, SymSetOptions,
+    IMAGEHLP_MODULE64, SYMOPT_UNDNAME, SYM_LOAD_FLAGS,
 };
 use windows::Win32::System::LibraryLoader::GetModuleHandleExA;
 use windows::Win32::System::Threading::{OpenProcess, PROCESS_ALL_ACCESS};
@@ -48,6 +49,24 @@ pub unsafe fn get_explorer_handle() -> HANDLE {
             .as_u32();
 
     OpenProcess(PROCESS_ALL_ACCESS, FALSE, explorerid).unwrap()
+}
+
+/// Reads `expected.len()` bytes from the live explorer process at
+/// `shell32_base + rva` and returns true only if they exactly match `expected`.
+pub unsafe fn verify_rva(rva: u32, expected: &[u8]) -> bool {
+    let base = get_shell32_offset();
+    let handle = get_explorer_handle();
+    let addr = (base + rva as u64) as *const c_void;
+    let mut buf = vec![0u8; expected.len()];
+    let ok = ReadProcessMemory(
+        handle,
+        addr,
+        buf.as_mut_ptr() as *mut c_void,
+        buf.len(),
+        None,
+    );
+    CloseHandle(handle.0);
+    ok.is_ok() && buf == expected
 }
 
 pub unsafe fn get_shell32_modinfo() -> IMAGEHLP_MODULE64 {

--- a/src/fetch_pdb.rs
+++ b/src/fetch_pdb.rs
@@ -4,8 +4,18 @@ pub fn build_url(guid: String) -> String {
     format!("http://msdl.microsoft.com/download/symbols/shell32.pdb/{guid}/shell32.pdb")
 }
 
-pub fn fetch(url: String) -> Vec<u8> {
-    let resp = ureq::get(url.as_str()).call().unwrap();
+/// Returns None if the symbol server responds 404 (PDB not yet uploaded).
+/// Panics on any other network or HTTP error.
+pub fn try_fetch(url: String) -> Option<Vec<u8>> {
+    let resp = match ureq::get(url.as_str()).call() {
+        Ok(r) => r,
+        Err(ureq::Error::Status(404, _)) => {
+            println!("Symbol server returned 404 — PDB not yet available.");
+            return None;
+        }
+        Err(e) => panic!("Failed to fetch PDB: {e}"),
+    };
+
     let len: usize = if resp.has("Content-Length") {
         resp.header("Content-Length").unwrap().parse().unwrap()
     } else {
@@ -18,5 +28,5 @@ pub fn fetch(url: String) -> Vec<u8> {
         .take(u64::MAX)
         .read_to_end(&mut buf)
         .unwrap();
-    buf
+    Some(buf)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,22 @@ fn rva() -> u32 {
 }
 
 fn inject() {
+    use std::path::Path;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    loop {
+        let sys = sysinfo::System::new_with_specifics(
+            sysinfo::RefreshKind::new().with_processes(sysinfo::ProcessRefreshKind::everything()),
+        );
+        if sys.processes().values().any(|p| {
+            p.exe().map_or(false, |exe| exe == Path::new(r"C:\Windows\explorer.exe"))
+        }) {
+            break;
+        }
+        sleep(Duration::from_millis(500));
+    }
+
     unsafe {
         inject::inject(rva());
         inject::refresh();

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,9 @@ mod explorer_modinfo;
 mod fetch_pdb;
 mod inject;
 mod parse_pdb;
+mod scan_dll;
+mod scheduled_task;
+mod structural_scan;
 
 fn prog() -> String {
     // modified from https://stackoverflow.com/a/58113997/9044183
@@ -45,21 +48,33 @@ fn inject() {
         inject::refresh();
     }
 }
+
+fn patch_rva(hex: &str) {
+    let rva = u32::from_str_radix(hex.trim_start_matches("0x").trim_start_matches("0X"), 16)
+        .unwrap_or_else(|_| panic!("invalid hex RVA: {hex}"));
+    println!("RVA is {rva:#x}");
+    cache_pdb::seed_rva(rva);
+    unsafe {
+        inject::inject(rva);
+        inject::refresh();
+    }
+}
+
 fn main() {
-    match env::args().collect::<Vec<String>>().get(1) {
-        None => inject(),
-        Some(arg) => match arg.as_str() {
-            "inject" => inject(),
-            "help" => help(),
-            "about" => {
-                println!(include_str!("../about.txt"), env!("CARGO_PKG_VERSION"))
-            }
-            err => {
-                eprintln!(
-                    "Invalid argument `{err}`. Run `{} help` to see all commands.",
-                    prog()
-                )
-            }
+    let args: Vec<String> = env::args().collect();
+    match args.get(1).map(String::as_str) {
+        None | Some("inject") => inject(),
+        Some("patch-rva") => match args.get(2) {
+            Some(hex) => patch_rva(hex),
+            None => eprintln!("Usage: {} patch-rva <hex-rva>  (e.g. patch-rva 1C4934)", prog()),
         },
+        Some("install-task") => scheduled_task::install_task(),
+        Some("remove-task")  => scheduled_task::remove_task(),
+        Some("help") => help(),
+        Some("about") => println!(include_str!("../about.txt"), env!("CARGO_PKG_VERSION")),
+        Some(err) => eprintln!(
+            "Invalid argument `{err}`. Run `{} help` to see all commands.",
+            prog()
+        ),
     }
 }

--- a/src/scan_dll.rs
+++ b/src/scan_dll.rs
@@ -1,0 +1,194 @@
+use std::fs;
+
+use crate::constants::SHELL32_PATH;
+
+pub(crate) struct Section {
+    virtual_size: u32,
+    virtual_address: u32,
+    raw_size: u32,
+    ptr_to_raw: u32,
+    characteristics: u32,
+}
+
+pub(crate) fn parse_sections(dll: &[u8]) -> Vec<Section> {
+    let e_lfanew = u32::from_le_bytes(dll[0x3C..0x40].try_into().unwrap()) as usize;
+    let num_sections =
+        u16::from_le_bytes(dll[e_lfanew + 6..e_lfanew + 8].try_into().unwrap()) as usize;
+    let opt_hdr_size =
+        u16::from_le_bytes(dll[e_lfanew + 20..e_lfanew + 22].try_into().unwrap()) as usize;
+    // PE sig (4) + COFF header (20) + optional header
+    let sec_base = e_lfanew + 24 + opt_hdr_size;
+
+    (0..num_sections)
+        .map(|i| {
+            let b = sec_base + i * 40;
+            Section {
+                virtual_size: u32::from_le_bytes(dll[b + 8..b + 12].try_into().unwrap()),
+                virtual_address: u32::from_le_bytes(dll[b + 12..b + 16].try_into().unwrap()),
+                raw_size: u32::from_le_bytes(dll[b + 16..b + 20].try_into().unwrap()),
+                ptr_to_raw: u32::from_le_bytes(dll[b + 20..b + 24].try_into().unwrap()),
+                characteristics: u32::from_le_bytes(dll[b + 36..b + 40].try_into().unwrap()),
+            }
+        })
+        .collect()
+}
+
+pub fn read_dll() -> Vec<u8> {
+    fs::read(SHELL32_PATH).expect("failed to read shell32.dll from disk")
+}
+
+pub fn rva_to_file_offset(dll: &[u8], rva: u32) -> Option<u32> {
+    for s in parse_sections(dll) {
+        let span = s.virtual_size.max(s.raw_size);
+        if rva >= s.virtual_address && rva < s.virtual_address + span {
+            return Some(rva - s.virtual_address + s.ptr_to_raw);
+        }
+    }
+    None
+}
+
+pub fn file_offset_to_rva(dll: &[u8], offset: u32) -> Option<u32> {
+    for s in parse_sections(dll) {
+        if offset >= s.ptr_to_raw && offset < s.ptr_to_raw + s.raw_size {
+            return Some(offset - s.ptr_to_raw + s.virtual_address);
+        }
+    }
+    None
+}
+
+pub fn read_at_rva(dll: &[u8], rva: u32, count: usize) -> Option<Vec<u8>> {
+    let off = rva_to_file_offset(dll, rva)? as usize;
+    if off + count > dll.len() {
+        return None;
+    }
+    Some(dll[off..off + count].to_vec())
+}
+
+const IMAGE_SCN_MEM_EXECUTE: u32 = 0x2000_0000;
+
+/// Returns file offsets (not RVAs) of every match within executable sections.
+pub fn scan_for_pattern(dll: &[u8], pattern: &[u8]) -> Vec<u32> {
+    let mut hits = Vec::new();
+    for s in parse_sections(dll) {
+        if s.characteristics & IMAGE_SCN_MEM_EXECUTE == 0 {
+            continue;
+        }
+        let start = s.ptr_to_raw as usize;
+        let end = (s.ptr_to_raw + s.raw_size) as usize;
+        if end > dll.len() {
+            continue;
+        }
+        for (i, window) in dll[start..end].windows(pattern.len()).enumerate() {
+            if window == pattern {
+                hits.push(s.ptr_to_raw + i as u32);
+            }
+        }
+    }
+    hits
+}
+
+// ── patterns.bin format ────────────────────────────────────────────────────
+//
+// [u8  version = 1]
+// [u8  count]
+// count × {
+//   [u32 relative_offset_from_func_entry  (little-endian)]
+//   [u8  length]
+//   [length × u8 bytes]
+// }
+//
+// Offsets are collected at: 0 (prologue), 8, 30, 60 bytes into the function.
+// The first entry always has relative_offset == 0 and serves as the scan anchor.
+
+const PATTERN_SPECS: &[(u32, usize)] = &[(0, 8), (8, 8), (30, 8), (60, 8)];
+
+/// Build a patterns.bin payload from a known function RVA in the on-disk DLL.
+pub fn save_patterns(dll: &[u8], func_rva: u32) -> Option<Vec<u8>> {
+    let mut entries: Vec<(u32, Vec<u8>)> = Vec::new();
+    for &(rel_off, len) in PATTERN_SPECS {
+        if let Some(bytes) = read_at_rva(dll, func_rva + rel_off, len) {
+            entries.push((rel_off, bytes));
+        }
+    }
+    if entries.is_empty() {
+        return None;
+    }
+    let mut buf = vec![1u8, entries.len() as u8]; // version, count
+    for (rel_off, bytes) in &entries {
+        buf.extend_from_slice(&rel_off.to_le_bytes());
+        buf.push(bytes.len() as u8);
+        buf.extend_from_slice(bytes);
+    }
+    Some(buf)
+}
+
+/// Parse a patterns.bin payload into a list of (relative_offset, bytes) pairs.
+pub fn load_patterns(data: &[u8]) -> Option<Vec<(u32, Vec<u8>)>> {
+    if data.len() < 2 || data[0] != 1 {
+        return None;
+    }
+    let count = data[1] as usize;
+    let mut patterns = Vec::with_capacity(count);
+    let mut pos = 2usize;
+    for _ in 0..count {
+        if pos + 5 > data.len() {
+            return None;
+        }
+        let rel_off = u32::from_le_bytes(data[pos..pos + 4].try_into().ok()?);
+        let len = data[pos + 4] as usize;
+        pos += 5;
+        if pos + len > data.len() {
+            return None;
+        }
+        patterns.push((rel_off, data[pos..pos + len].to_vec()));
+        pos += len;
+    }
+    Some(patterns)
+}
+
+/// Scan executable sections for a multi-pattern match.
+///
+/// `patterns` is a list of (relative_offset_from_func_entry, bytes).  The
+/// first entry must have relative_offset == 0 and acts as the search anchor.
+/// A candidate position passes only if *every* pattern matches at its
+/// relative offset from that position.
+///
+/// Returns file offsets of matching function entries.
+pub fn scan_for_multi_pattern(dll: &[u8], patterns: &[(u32, Vec<u8>)]) -> Vec<u32> {
+    let Some((anchor_off, anchor_bytes)) = patterns.first() else {
+        return vec![];
+    };
+    if *anchor_off != 0 || anchor_bytes.is_empty() {
+        return vec![];
+    }
+
+    let mut hits = Vec::new();
+    for s in parse_sections(dll) {
+        if s.characteristics & IMAGE_SCN_MEM_EXECUTE == 0 {
+            continue;
+        }
+        let start = s.ptr_to_raw as usize;
+        let end = (s.ptr_to_raw + s.raw_size).min(dll.len() as u32) as usize;
+        if end < start + anchor_bytes.len() {
+            continue;
+        }
+
+        'outer: for i in 0..=(end - start - anchor_bytes.len()) {
+            let candidate = start + i;
+            if &dll[candidate..candidate + anchor_bytes.len()] != anchor_bytes.as_slice() {
+                continue;
+            }
+            for (rel_off, bytes) in &patterns[1..] {
+                let check = candidate + *rel_off as usize;
+                if check + bytes.len() > end {
+                    continue 'outer;
+                }
+                if &dll[check..check + bytes.len()] != bytes.as_slice() {
+                    continue 'outer;
+                }
+            }
+            hits.push(s.ptr_to_raw + i as u32);
+        }
+    }
+    hits
+}

--- a/src/scheduled_task.rs
+++ b/src/scheduled_task.rs
@@ -1,12 +1,7 @@
 use std::env;
+use std::fs;
 use std::process::Command;
 
-/// Install a Windows scheduled task that re-runs `uwd2 inject` at every
-/// interactive logon (including session reconnect).
-///
-/// Uses PowerShell's `Register-ScheduledTask` so no COM interop is needed.
-/// Requires elevation; if not elevated the PowerShell call will fail with a
-/// permission error.
 pub fn install_task() {
     let exe = match env::current_exe() {
         Ok(p) => p,
@@ -15,15 +10,26 @@ pub fn install_task() {
             return;
         }
     };
+
+    let vbs_path = exe.with_file_name("uwd2_launch.vbs");
     let exe_str = exe.to_string_lossy();
-    // Escape single quotes for PowerShell string literals
-    let exe_escaped = exe_str.replace('\'', "''");
+    let vbs = format!(
+        "CreateObject(\"WScript.Shell\").Run Chr(34) & \"{exe}\" & Chr(34) & \" inject\", 0, True\r\n",
+        exe = exe_str.replace('"', "\"\"")
+    );
+    if let Err(e) = fs::write(&vbs_path, vbs.as_bytes()) {
+        eprintln!("Cannot write launcher script: {e}");
+        return;
+    }
+
+    let vbs_str = vbs_path.to_string_lossy();
+    let vbs_ps = vbs_str.replace('\'', "''");
 
     let script = format!(
         r#"
 $ErrorActionPreference = 'Stop'
-$exe = '{exe_escaped}'
-$action   = New-ScheduledTaskAction -Execute $exe -Argument 'inject'
+$vbs      = '{vbs_ps}'
+$action   = New-ScheduledTaskAction -Execute 'wscript.exe' -Argument ('//nologo "' + $vbs + '"')
 $trigger  = New-ScheduledTaskTrigger -AtLogOn
 $settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries `
@@ -44,7 +50,7 @@ Register-ScheduledTask `
     -Force | Out-Null
 Write-Host 'Task registered.'
 "#,
-        exe_escaped = exe_escaped
+        vbs_ps = vbs_ps
     );
 
     let status = Command::new("powershell")
@@ -63,20 +69,19 @@ Write-Host 'Task registered.'
             println!("Scheduled task 'UWD2_WatermarkRemover' installed.");
             println!("UWD2 will now run automatically at every logon.");
         }
-        Ok(s) => {
-            eprintln!(
-                "PowerShell exited with code {:?}. Try running uwd2 as administrator.",
-                s.code()
-            );
-        }
-        Err(e) => {
-            eprintln!("Failed to launch PowerShell: {e}");
-        }
+        Ok(s) => eprintln!(
+            "PowerShell exited with code {:?}. Try running uwd2 as administrator.",
+            s.code()
+        ),
+        Err(e) => eprintln!("Failed to launch PowerShell: {e}"),
     }
 }
 
-/// Remove the scheduled task installed by `install_task`.
 pub fn remove_task() {
+    if let Ok(exe) = env::current_exe() {
+        let _ = fs::remove_file(exe.with_file_name("uwd2_launch.vbs"));
+    }
+
     let script = r#"
 $ErrorActionPreference = 'Stop'
 Unregister-ScheduledTask -TaskName 'UWD2_WatermarkRemover' -Confirm:$false

--- a/src/scheduled_task.rs
+++ b/src/scheduled_task.rs
@@ -1,0 +1,105 @@
+use std::env;
+use std::process::Command;
+
+/// Install a Windows scheduled task that re-runs `uwd2 inject` at every
+/// interactive logon (including session reconnect).
+///
+/// Uses PowerShell's `Register-ScheduledTask` so no COM interop is needed.
+/// Requires elevation; if not elevated the PowerShell call will fail with a
+/// permission error.
+pub fn install_task() {
+    let exe = match env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Cannot determine current exe path: {e}");
+            return;
+        }
+    };
+    let exe_str = exe.to_string_lossy();
+    // Escape single quotes for PowerShell string literals
+    let exe_escaped = exe_str.replace('\'', "''");
+
+    let script = format!(
+        r#"
+$ErrorActionPreference = 'Stop'
+$exe = '{exe_escaped}'
+$action   = New-ScheduledTaskAction -Execute $exe -Argument 'inject'
+$trigger  = New-ScheduledTaskTrigger -AtLogOn
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 2) `
+    -StartWhenAvailable
+$principal = New-ScheduledTaskPrincipal `
+    -UserId ([System.Security.Principal.WindowsIdentity]::GetCurrent().Name) `
+    -LogonType Interactive `
+    -RunLevel Highest
+Register-ScheduledTask `
+    -TaskName    'UWD2_WatermarkRemover' `
+    -Action      $action `
+    -Trigger     $trigger `
+    -Settings    $settings `
+    -Principal   $principal `
+    -Description 'UWD2: removes the Windows Insider evaluation watermark at logon.' `
+    -Force | Out-Null
+Write-Host 'Task registered.'
+"#,
+        exe_escaped = exe_escaped
+    );
+
+    let status = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &script,
+        ])
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {
+            println!("Scheduled task 'UWD2_WatermarkRemover' installed.");
+            println!("UWD2 will now run automatically at every logon.");
+        }
+        Ok(s) => {
+            eprintln!(
+                "PowerShell exited with code {:?}. Try running uwd2 as administrator.",
+                s.code()
+            );
+        }
+        Err(e) => {
+            eprintln!("Failed to launch PowerShell: {e}");
+        }
+    }
+}
+
+/// Remove the scheduled task installed by `install_task`.
+pub fn remove_task() {
+    let script = r#"
+$ErrorActionPreference = 'Stop'
+Unregister-ScheduledTask -TaskName 'UWD2_WatermarkRemover' -Confirm:$false
+Write-Host 'Task removed.'
+"#;
+
+    let status = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+        ])
+        .status();
+
+    match status {
+        Ok(s) if s.success() => println!("Scheduled task removed."),
+        Ok(s) => eprintln!(
+            "PowerShell exited with code {:?}. The task may not have been installed.",
+            s.code()
+        ),
+        Err(e) => eprintln!("Failed to launch PowerShell: {e}"),
+    }
+}

--- a/src/structural_scan.rs
+++ b/src/structural_scan.rs
@@ -1,0 +1,264 @@
+/// Structural scan for `CDesktopWatermark::s_DesktopBuildPaint` that requires
+/// no cached state.
+///
+/// Strategy (plan §A2):
+///   1. Resolve the IAT slot RVA of `SetTextColor` in `GDI32.DLL`.
+///   2. Scan the executable sections for `FF 15 [disp32]` (CALL [rip+X])
+///      whose computed target equals that IAT slot.
+///   3. For each such call site, check the 24 bytes before it for a load of
+///      `0x00FFFFFF` into edx / r8d — the white text color argument.
+///   4. Find the enclosing function's start address via the `.pdata`
+///      (RUNTIME_FUNCTION) exception directory; fall back to a backward
+///      prologue walk if .pdata is absent.
+///   5. Return the function's RVA.
+
+use crate::scan_dll::{file_offset_to_rva, rva_to_file_offset};
+
+// ── PE helper types ────────────────────────────────────────────────────────
+
+struct ExecSection {
+    virtual_address: u32,
+    ptr_to_raw: u32,
+    raw_size: u32,
+}
+
+/// Returns (virtual_address, ptr_to_raw, raw_size) for every executable section.
+fn executable_sections(dll: &[u8]) -> Vec<ExecSection> {
+    let Ok(e_lfanew_bytes) = dll[0x3C..0x40].try_into() else { return vec![] };
+    let e_lfanew = u32::from_le_bytes(e_lfanew_bytes) as usize;
+    if e_lfanew + 24 > dll.len() { return vec![]; }
+    let num_sections =
+        u16::from_le_bytes(dll[e_lfanew + 6..e_lfanew + 8].try_into().unwrap_or([0; 2])) as usize;
+    let opt_hdr_size =
+        u16::from_le_bytes(dll[e_lfanew + 20..e_lfanew + 22].try_into().unwrap_or([0; 2])) as usize;
+    let sec_base = e_lfanew + 24 + opt_hdr_size;
+
+    const IMAGE_SCN_MEM_EXECUTE: u32 = 0x2000_0000;
+    let mut out = Vec::new();
+    for i in 0..num_sections {
+        let b = sec_base + i * 40;
+        if b + 40 > dll.len() { break; }
+        let characteristics = u32::from_le_bytes(dll[b + 36..b + 40].try_into().unwrap());
+        if characteristics & IMAGE_SCN_MEM_EXECUTE == 0 { continue; }
+        out.push(ExecSection {
+            virtual_address: u32::from_le_bytes(dll[b + 12..b + 16].try_into().unwrap()),
+            raw_size:        u32::from_le_bytes(dll[b + 16..b + 20].try_into().unwrap()),
+            ptr_to_raw:      u32::from_le_bytes(dll[b + 20..b + 24].try_into().unwrap()),
+        });
+    }
+    out
+}
+
+// ── IAT lookup ────────────────────────────────────────────────────────────
+
+/// Find the IAT slot RVA for `func_name` exported by `dll_name` (case-insensitive).
+///
+/// Parses IMAGE_IMPORT_DESCRIPTOR → OriginalFirstThunk (name thunks) to
+/// match by name, then returns FirstThunk + index*8 as the slot RVA.
+fn find_iat_slot_rva(dll: &[u8], dll_name: &str, func_name: &str) -> Option<u32> {
+    let e_lfanew = u32::from_le_bytes(dll[0x3C..0x40].try_into().ok()?) as usize;
+    let opt_hdr = e_lfanew + 24;
+    if opt_hdr + 2 > dll.len() { return None; }
+
+    // Require PE32+ (Magic = 0x020B)
+    let magic = u16::from_le_bytes(dll[opt_hdr..opt_hdr + 2].try_into().ok()?);
+    if magic != 0x020B { return None; }
+
+    // DataDirectory[1] (Import Directory) is at optional-header offset 120
+    let import_dir_rva =
+        u32::from_le_bytes(dll[opt_hdr + 120..opt_hdr + 124].try_into().ok()?);
+    if import_dir_rva == 0 { return None; }
+    let import_file = rva_to_file_offset(dll, import_dir_rva)? as usize;
+
+    // Walk IMAGE_IMPORT_DESCRIPTOR array (20 bytes per entry, null-terminated)
+    let mut desc = import_file;
+    loop {
+        if desc + 20 > dll.len() { return None; }
+        let orig_first_thunk = u32::from_le_bytes(dll[desc..desc + 4].try_into().ok()?);
+        let first_thunk      = u32::from_le_bytes(dll[desc + 16..desc + 20].try_into().ok()?);
+        if orig_first_thunk == 0 && first_thunk == 0 { break; } // null terminator
+
+        let name_rva = u32::from_le_bytes(dll[desc + 12..desc + 16].try_into().ok()?);
+        if let Some(name_file) = rva_to_file_offset(dll, name_rva) {
+            let name_file = name_file as usize;
+            if let Some(nul) = dll[name_file..].iter().position(|&b| b == 0) {
+                if let Ok(this_dll) = std::str::from_utf8(&dll[name_file..name_file + nul]) {
+                    if this_dll.eq_ignore_ascii_case(dll_name) {
+                        // Found the right DLL — walk its name thunks
+                        if let Some(idx) =
+                            find_named_import_index(dll, orig_first_thunk, func_name)
+                        {
+                            return Some(first_thunk + idx as u32 * 8);
+                        }
+                    }
+                }
+            }
+        }
+        desc += 20;
+    }
+    None
+}
+
+/// Walk OriginalFirstThunk IMAGE_THUNK_DATA64 entries looking for `name`.
+/// Returns the 0-based index of the match, or None.
+fn find_named_import_index(dll: &[u8], orig_first_thunk_rva: u32, name: &str) -> Option<usize> {
+    let thunk_file = rva_to_file_offset(dll, orig_first_thunk_rva)? as usize;
+    let mut idx = 0usize;
+    loop {
+        let off = thunk_file + idx * 8;
+        if off + 8 > dll.len() { return None; }
+        let val = u64::from_le_bytes(dll[off..off + 8].try_into().ok()?);
+        if val == 0 { return None; }
+        if val & 0x8000_0000_0000_0000 == 0 {
+            // import by name: val is RVA to IMAGE_IMPORT_BY_NAME
+            let ibn_file = rva_to_file_offset(dll, val as u32)? as usize + 2; // skip Hint
+            if let Some(nul) = dll[ibn_file..].iter().position(|&b| b == 0) {
+                if let Ok(n) = std::str::from_utf8(&dll[ibn_file..ibn_file + nul]) {
+                    if n == name { return Some(idx); }
+                }
+            }
+        }
+        idx += 1;
+    }
+}
+
+// ── CALL-site discovery ────────────────────────────────────────────────────
+
+/// Return the file offset of every `FF 15 [disp32]` (CALL [rip+X]) in executable
+/// sections whose displacement resolves to `target_rva`.
+fn find_indirect_calls(dll: &[u8], target_rva: u32) -> Vec<usize> {
+    let mut out = Vec::new();
+    for s in executable_sections(dll) {
+        let start = s.ptr_to_raw as usize;
+        let end = (s.ptr_to_raw + s.raw_size).min(dll.len() as u32) as usize;
+        if end < start + 6 { continue; }
+        for i in 0..=(end - start - 6) {
+            if dll[start + i] != 0xFF || dll[start + i + 1] != 0x15 { continue; }
+            let disp32 = i32::from_le_bytes(dll[start + i + 2..start + i + 6].try_into().unwrap());
+            // RVA of instruction = section_va + i;  next insn RVA = +6
+            let insn_rva = s.virtual_address + i as u32;
+            let target = (insn_rva as i64 + 6 + disp32 as i64) as u32;
+            if target == target_rva {
+                out.push(start + i);
+            }
+        }
+    }
+    out
+}
+
+// ── Color-load check ──────────────────────────────────────────────────────
+
+/// True if the 40 bytes before `call_site_file_offset` contain a load of
+/// 0x00FFFFFF into edx (second arg) or r8d (third arg).
+///
+/// Patterns:
+///   BA FF FF FF 00        mov edx,  0x00FFFFFF
+///   41 B8 FF FF FF 00     mov r8d,  0x00FFFFFF
+fn has_white_color_arg(dll: &[u8], call_site: usize) -> bool {
+    let search_start = call_site.saturating_sub(40);
+    let window = &dll[search_start..call_site];
+    let mov_edx: &[u8] = &[0xBA, 0xFF, 0xFF, 0xFF, 0x00];
+    let mov_r8d: &[u8] = &[0x41, 0xB8, 0xFF, 0xFF, 0xFF, 0x00];
+    window.windows(5).any(|w| w == mov_edx)
+        || window.windows(6).any(|w| w == mov_r8d)
+}
+
+// ── Function-start recovery ────────────────────────────────────────────────
+
+/// Look up the enclosing function start via the .pdata section
+/// (x64 RUNTIME_FUNCTION table, each entry 12 bytes:
+///  BeginAddress / EndAddress / UnwindData — all RVAs).
+fn find_func_via_pdata(dll: &[u8], call_site_rva: u32) -> Option<u32> {
+    let e_lfanew = u32::from_le_bytes(dll[0x3C..0x40].try_into().ok()?) as usize;
+    let opt_hdr = e_lfanew + 24;
+    if opt_hdr + 144 > dll.len() { return None; }
+
+    // DataDirectory[3] (Exception Directory) is at optional-header offset 136
+    let exc_rva  = u32::from_le_bytes(dll[opt_hdr + 136..opt_hdr + 140].try_into().ok()?);
+    let exc_size = u32::from_le_bytes(dll[opt_hdr + 140..opt_hdr + 144].try_into().ok()?);
+    if exc_rva == 0 || exc_size < 12 { return None; }
+
+    let exc_file = rva_to_file_offset(dll, exc_rva)? as usize;
+    let count = exc_size as usize / 12;
+    for i in 0..count {
+        let b = exc_file + i * 12;
+        if b + 8 > dll.len() { break; }
+        let begin = u32::from_le_bytes(dll[b..b + 4].try_into().ok()?);
+        let end   = u32::from_le_bytes(dll[b + 4..b + 8].try_into().ok()?);
+        if begin <= call_site_rva && call_site_rva < end {
+            return Some(begin);
+        }
+    }
+    None
+}
+
+/// Fallback: walk backward from `call_site_file_offset` to find the
+/// INT3 / NOP padding block that MSVC places between functions.
+/// The function entry is the first byte immediately after that padding.
+///
+/// This is less precise than .pdata but works if the exception directory is
+/// stripped.  Results are verified against the live process before use.
+fn find_func_via_prologue_walk(dll: &[u8], call_site_file_offset: usize) -> Option<u32> {
+    let limit = call_site_file_offset.saturating_sub(512);
+    // Walk backward until we hit the trailing INT3/NOP padding that precedes
+    // the function.  The first CC/90 we encounter is the last byte of that
+    // padding block; the function starts one byte later.
+    for pos in (limit..call_site_file_offset).rev() {
+        if dll[pos] == 0xCC || dll[pos] == 0x90 {
+            let func_start = pos + 1;
+            if func_start < call_site_file_offset {
+                return file_offset_to_rva(dll, func_start as u32);
+            }
+        }
+    }
+    None
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+/// Locate `CDesktopWatermark::s_DesktopBuildPaint` in the on-disk `shell32.dll`
+/// without any cached state.
+///
+/// Returns the function's RVA, or `None` if the heuristic couldn't find a
+/// single unambiguous match.
+pub fn find_by_gdi_calls(dll: &[u8]) -> Option<u32> {
+    let iat_rva = find_iat_slot_rva(dll, "GDI32.dll", "SetTextColor")?;
+
+    println!("SetTextColor IAT slot RVA: {iat_rva:#x}");
+
+    let call_sites = find_indirect_calls(dll, iat_rva);
+    println!("Found {} indirect call(s) to SetTextColor", call_sites.len());
+
+    let mut candidates: Vec<u32> = Vec::new();
+    for site in call_sites {
+        if !has_white_color_arg(dll, site) {
+            continue;
+        }
+        let site_rva = file_offset_to_rva(dll, site as u32)?;
+        let func_rva = find_func_via_pdata(dll, site_rva)
+            .or_else(|| find_func_via_prologue_walk(dll, site));
+        if let Some(rva) = func_rva {
+            if !candidates.contains(&rva) {
+                candidates.push(rva);
+            }
+        }
+    }
+
+    match candidates.len() {
+        0 => {
+            eprintln!("Structural scan: no SetTextColor(_, 0xFFFFFF) call found.");
+            None
+        }
+        1 => {
+            println!("Structural scan: unique candidate at RVA {:#x}", candidates[0]);
+            Some(candidates[0])
+        }
+        n => {
+            eprintln!("Structural scan: {n} candidates — ambiguous, skipping.");
+            for c in &candidates {
+                eprintln!("  candidate RVA: {c:#x}");
+            }
+            None
+        }
+    }
+}


### PR DESCRIPTION
Introduce multi-tier RVA resolution and automation features.

- Added scan_dll.rs: helpers to read/parse on-disk shell32.dll, section/RVA conversions, pattern save/load, and multi-pattern scanning.
- Added structural_scan.rs: structural GDI-call heuristic to locate CDesktopWatermark::s_DesktopBuildPaint without PDBs (IAT lookup, indirect-call discovery, arg checks, .pdata/prologue fallback).
- Added scheduled_task.rs: install/remove Windows scheduled task via PowerShell to re-run the inject command at logon.
- Expanded cache_pdb.rs: implement fallback chain (cached .rva, symbol server via try_fetch, multi-pattern binary scan using patterns.bin, structural scan, and panic with manual recovery instructions); save patterns.bin and manage cached .rva files; added seed_rva to accept manual patch-rva.
- Updated fetch_pdb.rs: try_fetch returns Option<Vec<u8>> and treats 404 as "PDB not yet available" while panicking on other network errors.
- Updated explorer_modinfo.rs: added verify_rva that reads live explorer.exe memory to verify bytes (uses ReadProcessMemory).
- Updated main.rs & help.txt: register new subcommands (patch-rva, install-task, remove-task), wire seed+inject flow for patch-rva, and document new commands in help text.

Overall this change improves robustness when PDBs are missing by enabling cached RVAs, binary-pattern scanning, structural heuristics, manual seeding, and automated re-patching across logons.

Fix for #21 